### PR TITLE
fix .off() should return "this" (for queuing)

### DIFF
--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -123,6 +123,8 @@ SOFTWARE.
             }
           }
         }, this);
+        
+        return this;
       },
       one: function(name, listener) {
         return this.on( name, listener, true );


### PR DESCRIPTION
detected error in $container.off(..).off(...).off(...) as off() should return "this" in order to queue functions, as defined correctly in .on()